### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="https://www.npmjs.org/package/terminal-detect"><img src="https://badgen.net/npm/dt/terminal-detect" alt="downloads"/></a>
   <a href="https://travis-ci.org/lirantal/terminal-detect"><img src="https://badgen.net/travis/lirantal/terminal-detect" alt="build"/></a>
   <a href="https://codecov.io/gh/lirantal/terminal-detect"><img src="https://badgen.net/codecov/c/github/lirantal/terminal-detect" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/terminal-detect"><img src="https://snyk.io/test/github/lirantal/terminal-detect/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.